### PR TITLE
feat: upgrade jupyter-server-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN pip install --no-cache-dir jupyterlab-git && \
 
 # Add support for Widgets & Plots
 RUN pip install --no-cache-dir ipywidgets \
-      ipyleaflet && \
+    ipyleaflet && \
     jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
     jupyter nbextension enable --py widgetsnbextension --sys-prefix && \
     jupyter labextension install jupyter-leaflet
@@ -40,15 +40,15 @@ RUN pip install --no-cache-dir dask_labextension && \
 
 # Bake Dask/Dask-Kubernetes libraries into base Conda Environment
 RUN conda install -y \
-      dask=2.30 \
-      distributed=2.30 \
-      dask-kubernetes=0.10.1 \
-      dask-gateway=0.8 \
-      jupyter-server-proxy=1.1.0 \
-      bokeh=1 \
-      tornado=6 \
-      nbgitpuller=0.8 \
-      lz4=3.1.0
+    dask=2.30 \
+    distributed=2.30 \
+    dask-kubernetes=0.10.1 \
+    dask-gateway=0.8 \
+    jupyter-server-proxy=1.5.0 \
+    bokeh=1 \
+    tornado=6 \
+    nbgitpuller=0.8 \
+    lz4=3.1.0
 
 USER root
 


### PR DESCRIPTION
Upgrade jupyter-server-proxy in order to test with dask dashboard on a machine other than localhost.