### PR TITLE
NERCDL-956 add dask to conda install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV NB_GID 100
 ENV HOME /home/datalab
 ENV CONDA_DIR /opt/conda
 ENV JUPYTER_ENABLE_LAB="yes"
+ENV DASK_VERSION 2.30
 WORKDIR /home/$NB_USER/work
 
 USER root
@@ -40,8 +41,8 @@ RUN pip install --no-cache-dir dask-labextension==5.0.0
 
 # Bake Dask/Dask-Kubernetes libraries into base Conda Environment
 RUN conda install -y \
-    dask=2.30 \
-    distributed=2.30 \
+    dask=$DASK_VERSION \
+    distributed=$DASK_VERSION \
     dask-kubernetes=0.10.1 \
     dask-gateway=0.8 \
     jupyter-server-proxy=1.5.0 \

--- a/env-control
+++ b/env-control
@@ -57,10 +57,10 @@ function create_env {
   logger "Building JupyterLab assets"
   jupyter lab build --minimize=False
 
-  logger "Installing ipykernel & irkernel"
-  conda install ipykernel r-irkernel readline -y
+  logger "Installing dask, ipykernel & irkernel"
+  conda install dask=$DASK_VERSION ipykernel r-irkernel readline -y
   if [ "$?" != "0" ]; then
-    error "Failed to install ipython and irkernel"
+    error "Failed to install dask, ipython and irkernel"
   fi
 
   logger "Setting up python Kernel"


### PR DESCRIPTION
Adds versioned Dask to the conda install done by env-control when it adds a Conda environment.