### PR TITLE
feat: set permissions on /home/datalabs/.jupyter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN wget -q https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.1
 
 # Set up Datalab user (replacing default jovyan user)
 RUN usermod -l $NB_USER -d /home/$NB_USER jovyan && \
+    mkdir -p /home/$NB_USER/.jupyter && \
     mkdir -p $CONDA_DIR/pkgs/cache && \
     chown -R $NB_USER:$NB_GID /home/$NB_USER $CONDA_DIR/pkgs/cache && \
     fix-permissions $CONDA_DIR


### PR DESCRIPTION
In order to make the Dask dashboard visible through Jupyter ServerProxy, a config file is now mounted to /home/datalab/.jupyter/jupyter_notebook_config.py.

At the moment, the /home/datalab/.jupyter folder isn't first created, so when the mounting happens that folder is created read-only.

This causes the creation of Conda environments to fail, with
```
  File "/opt/conda/lib/python3.8/site-packages/jupyter_core/migrate.py", line 245, in migrate
    with open(os.path.join(env['jupyter_config'], 'migrated'), 'w') as f:
PermissionError: [Errno 13] Permission denied: '/home/datalab/.jupyter/migrated'
```

This change should fix that, by first creating the /home/datalab/.jupyter folder so that it is given the same permissions as /home/datalab, which will mean that /home/datalab/.jupyter/migrated will no longer give permission deined..